### PR TITLE
replace `chunks` `Strategy` for a sentence `Rule`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ mod tests {
         }
 
         #[test]
-        fn rejects_missing_punctuation(s in chunks()) {
+        fn rejects_missing_punctuation(s in valid_sentence()) {
             let parsed = SentenceParser::parse(Rule::sentence, s.as_str());
             prop_assert!(parsed.is_err());
         }


### PR DESCRIPTION
Feels like a pasting miss.